### PR TITLE
First tweaks

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 import os
+from subprocess import run
 
-
-def main():
+def addback_newlines():
     """Adds newlines back to every file, to make them PEP8 compliant."""
     root_path = os.getcwd()
     for dirpath, dirnames, filenames in os.walk(root_path):
@@ -16,6 +16,14 @@ def main():
                     with open(path, 'wb') as f:
                         f.write((contents + b'\n').lstrip())
 
+def initialize_repo():
+    try:
+        run("git init".split())
+        run(("git remote add github " +
+                   "https://{{ cookiecutter.github_username }}@github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}.git").split())
+    except CalledProcessError as e:
+        print('Repository initialization failed' + e)
 
 if __name__ == '__main__':
-    main()
+    addback_newlines()
+    initialize_repo()

--- a/{{ cookiecutter.repo_name }}/.gitignore
+++ b/{{ cookiecutter.repo_name }}/.gitignore
@@ -6,3 +6,4 @@ build/
 
 .tox/
 .coverage
+.pytest_cache

--- a/{{ cookiecutter.repo_name }}/tests/__init__.py
+++ b/{{ cookiecutter.repo_name }}/tests/__init__.py
@@ -1,1 +1,1 @@
-
+''' Module automatic load '''

--- a/{{ cookiecutter.repo_name }}/tox.ini
+++ b/{{ cookiecutter.repo_name }}/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py26, py27, py33, py34, pypy, flake8
+envlist=py36, flake8
 
 [testenv]
 commands=py.test --cov {{ cookiecutter.package_name }} {posargs}
@@ -8,7 +8,6 @@ deps=
     pytest-cov
 
 [testenv:flake8]
-basepython = python2.7
 deps =
     flake8
 commands =


### PR DESCRIPTION
* Ignore pytest cache
* flake8 complains about empty trailing lines
* drop support for ancient pythons
* Refactor main and noop initialize repository
* Run commands to initialize project repository
* Update post_gen_project.py
* split out git arguments
* rtfd, hooks are run in the newly-created project dir
* Include github username in remote url
* extraneous py36